### PR TITLE
Fix: Left/Right clicks being consumed due to ALT modifier

### DIFF
--- a/DalamudPlugin/SmartPings/GroundPingView.cs
+++ b/DalamudPlugin/SmartPings/GroundPingView.cs
@@ -313,6 +313,13 @@ public class GroundPingView : IPluginUIView
             else
             {
                 this.presenter.Value.GroundPings.Clear();
+                // Clear any in-progress ping state so it can't carry over to the character
+                // select screen and cause SetNextFrameWantCaptureMouse to run every frame.
+                pingScreenPosition = null;
+                pingInput = null;
+                pingInputHeldDuration = 0;
+                pingWheelActive = false;
+                cursorIsPing = false;
             }
 
             unsafe
@@ -339,6 +346,10 @@ public class GroundPingView : IPluginUIView
 
     private bool IsAnyPingEnabled()
     {
+        if (!this.dalamud.PlayerState.IsLoaded)
+        {
+            return false;
+        }
         if (this.configuration.OnlyEnableInCombat && !this.dalamud.Condition.Any(ConditionFlag.InCombat))
         {
             return false;

--- a/DalamudPlugin/SmartPings/Input/InputEventSource.cs
+++ b/DalamudPlugin/SmartPings/Input/InputEventSource.cs
@@ -114,6 +114,7 @@ public sealed class InputEventSource : IDisposable
 
     private void OnMouseButtonDown(object? o, EventSourceEventArgs<ButtonDown> e)
     {
+        if (!IsGameFocused()) return;
         KeyCode keyCode;
         switch(e.Data.Button)
         {
@@ -140,6 +141,7 @@ public sealed class InputEventSource : IDisposable
     private void OnMouseButtonUp(object? o, EventSourceEventArgs<ButtonUp> e)
     {
         // Always listen to key ups, since these are necessary to cancel hold actions
+        if (!IsGameFocused()) return;
         KeyCode keyCode;
         switch(e.Data.Button)
         {


### PR DESCRIPTION
I've been able to replicate my issue and determined that if you have `ALT` bound as your `Hold Ping Keybind` and you `ALT+TAB` from the main menu/character select screen, mouse clicks are unresponsive because they are being consumed by the plugin.

I've hopefully added some protection to prevent this behavior.